### PR TITLE
Support import statements, support importing org-tables as objects, small refactor

### DIFF
--- a/README.org
+++ b/README.org
@@ -41,7 +41,7 @@ ob-deno can be installed from MELPA.
 
 The results parameter is default value.
 
-#+begin_example
+#+begin_example org
   ,#+begin_src deno
   const arr = [1, 2, 3];
   return arr;
@@ -53,7 +53,7 @@ The results parameter is default value.
 
 The results parameter is output.
 
-#+begin_example
+#+begin_example org
   ,#+begin_src deno :results output
   const arr = [1, 2, 3];
   console.log(arr);
@@ -65,7 +65,7 @@ The results parameter is output.
 
 Specify variables.
 
-#+begin_example
+#+begin_example org
   ,#+begin_src deno :var foo="bar" baz='("qux")
   return {foo, baz};
   ,#+end_src
@@ -76,7 +76,7 @@ Specify variables.
 
 Run with ~--allow-net~. (equivalent to ~deno run --allow-net~)
 
-#+begin_example
+#+begin_example org
   ,#+begin_src deno :allow net :results output
     const response = await fetch("https://httpbin.org/get?hello=world");
     const json = await response.json();
@@ -90,7 +90,7 @@ Run with ~--allow-net~. (equivalent to ~deno run --allow-net~)
 
 More complex. (equivalent to ~deno run --allow-net=httpbin.org,example.com --allow-env~)
 
-#+begin_example
+#+begin_example org
   ,#+begin_src deno :allow '((net . (httpbin.org example.com)) env) :results output
     const response = await fetch(`https://httpbin.org/get?user=${Deno.env.get("USER")}`);
     const json = await response.json();
@@ -100,4 +100,49 @@ More complex. (equivalent to ~deno run --allow-net=httpbin.org,example.com --all
 
   ,#+RESULTS:
   : { user: "taiju" }
+#+end_example
+
+It also supports imports and table inputs. You can use ~M-x org-babel-expand-src-block~ to check the generated code.
+
+#+begin_example org
+  ,#+NAME: writing-speed-practice
+  | Date         | Speed     | Accuracy |
+  |--------------+-----------+----------|
+  | [2024-10-26] | 73.6 WPM  |      91% |
+  | [2024-10-27] | 73.75 WPM |    88.5% |
+  | [2024-10-28] | 76.2 WPM  |    92.5% |
+  | [2024-11-01] | 75.66 WPM |   90.05% |
+  | [2024-11-02] | 77.69 WPM |   90.76% |
+  | [2024-11-04] | 79.3 WPM  |    91.6% |
+  | [2024-11-10] | 78.9 WPM  |    91.3% |
+
+  ,#+begin_src deno :allow 'all :var data=writing-speed-practice :file /tmp/plot.svg :results output file
+  import * as Plot from "npm:@observablehq/plot";
+  import { JSDOM } from "npm:jsdom";
+
+  data.forEach((x) => {
+    x.date = new Date(x.date.replace(/[\[\]]/g, ""));
+    x.speed = parseFloat(x.speed);
+    x.accuracy = parseFloat(x.accuracy);
+  });
+
+  const plot = Plot.plot({
+    document: new JSDOM("").window.document,
+    legend: true,
+    grid: true,
+    margin: 50,
+    marks: [
+      Plot.line(data, {x: "date", y: "speed", stroke: "blue"}),
+      Plot.line(data, {x: "date", y: "accuracy", stroke: "red",}),
+    ],
+  });
+
+  plot.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns", "http://www.w3.org/2000/svg");
+  plot.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:xlink", "http://www.w3.org/1999/xlink");
+
+  console.log(plot.outerHTML);
+  ,#+end_src
+
+  ,#+RESULTS:
+  [[file:/tmp/plot.svg]]
 #+end_example

--- a/ob-deno.el
+++ b/ob-deno.el
@@ -38,7 +38,7 @@
   :group 'ob-deno
   :type 'string)
 
-(defcustom ob-deno-variable-prefix "const"
+(defcustom ob-deno-variable-prefix "let"
   "Type of variable prefix."
   :group 'ob-deno
   :type '(choice (const "const")

--- a/ob-deno.el
+++ b/ob-deno.el
@@ -6,7 +6,7 @@
 ;; Keywords: literate programming, reproducible research, javascript, typescript, tools
 ;; Homepage: https://github.com/taiju/ob-deno
 ;; Version: 1.0.1
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "29.1") (s "1.13.0") (dash "2.11.0"))
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ob-deno.el
+++ b/ob-deno.el
@@ -47,7 +47,7 @@
   :safe #'stringp)
 
 (defvar ob-deno-function-wrapper
-  "Deno.stdout.write(new TextEncoder().encode(Deno.inspect((() => {%s})())));"
+  "Deno.stdout.write(new TextEncoder().encode(Deno.inspect(await (async () => {%s})())));"
   "Javascript/TypeScript code to print value of body.")
 
 (defun org-babel-execute:deno (body params)

--- a/ob-deno.el
+++ b/ob-deno.el
@@ -29,6 +29,8 @@
 
 ;;; Code:
 (require 'ob)
+(require 's)
+(require 'dash)
 
 (defvar org-babel-default-header-args:deno '()
   "Default header arguments for js/ts code blocks.")

--- a/ob-deno.el
+++ b/ob-deno.el
@@ -42,8 +42,8 @@
   "Type of variable prefix."
   :group 'ob-deno
   :type '(choice (const "const")
-		 (const "let")
-		 (const "var"))
+                 (const "let")
+                 (const "var"))
   :safe #'stringp)
 
 (defcustom ob-deno-function-wrapper
@@ -52,7 +52,7 @@
 %s is replaced with code body, without the imports.  Imports are
  injected to the beginning of the file."
   :group 'ob-deno
-  :type 'string )
+  :type 'string)
 
 (defconst ob-deno--treesit-imports-query
   (treesit-query-compile
@@ -96,25 +96,25 @@ produced code is a valid TypeScript code."
   You can also specify parameters in `PARAMS'.
   This function is called by `org-babel-execute-src-block'."
   (pcase-let* ((no-color-env (getenv "NO_COLOR"))
-	       (ob-deno-cmd (or (cdr (assq :cmd params)) (format "%s run" ob-deno-cmd)))
-	       (allow (ob-deno-allow-params (cdr (assq :allow params))))
-	       (ob-deno-cmd-with-permission (concat ob-deno-cmd " " allow))
+               (ob-deno-cmd (or (cdr (assq :cmd params)) (format "%s run" ob-deno-cmd)))
+               (allow (ob-deno-allow-params (cdr (assq :allow params))))
+               (ob-deno-cmd-with-permission (concat ob-deno-cmd " " allow))
                (result-type (cdr (assq :result-type params)))
                (`(,imports ,rest) (ob-deno--split-imports-and-rest body))
                (result (let ((script-file (concat (org-babel-temp-file "deno-script-") ".ts")))
-	                 (with-temp-file script-file
-	                   (insert
+                         (with-temp-file script-file
+                           (insert
                             (ob-deno--expand-body
                              imports
-	                     ;; return the value or the output
+                             ;; return the value or the output
                              (if (string= result-type "value")
-		                 (format ob-deno-function-wrapper rest)
-	                       rest)
+                                 (format ob-deno-function-wrapper rest)
+                               rest)
                              params)))
-	                 (setenv "NO_COLOR" "true")
-	                 (org-babel-eval
-	                  (format "%s %s" ob-deno-cmd-with-permission
-		                  (org-babel-process-file-name script-file)) ""))))
+                         (setenv "NO_COLOR" "true")
+                         (org-babel-eval
+                          (format "%s %s" ob-deno-cmd-with-permission
+                                  (org-babel-process-file-name script-file)) ""))))
     (setenv "NO_COLOR" no-color-env)
     (org-babel-result-cond (cdr (assq :result-params params))
       result (ob-deno-read result))))
@@ -145,16 +145,16 @@ If RESULTS look like a table, then convert them into an
 Emacs-lisp table, otherwise return the results as a string."
   (org-babel-read
    (if (and (stringp results)
-	    (string-prefix-p "[" results)
-	    (string-suffix-p "]" results))
+            (string-prefix-p "[" results)
+            (string-suffix-p "]" results))
        (org-babel-read
         (concat "'"
                 (replace-regexp-in-string
                  "\\[" "(" (replace-regexp-in-string
                             "\\]" ")" (replace-regexp-in-string
                                        ",[[:space:]]" " "
-				       (replace-regexp-in-string
-					"'" "\"" results))))))
+                                       (replace-regexp-in-string
+                                        "'" "\"" results))))))
      results)))
 
 (defun ob-deno-var-to-deno (var)

--- a/ob-deno.el
+++ b/ob-deno.el
@@ -84,7 +84,7 @@
    (org-babel-expand-body:generic
     rest params (org-babel-variable-assignments:deno params))))
 
-(defun org-babel-expand-body:deno (body params var-lines)
+(defun org-babel-expand-body:deno (body params &optional var-lines)
   "Expand BODY with PARAMS.
 This takes care of injecting parameters after the imports so that
 produced code is a valid TypeScript code."


### PR DESCRIPTION
Here is a small overview of what this PR does:

- Now it supports imports, using tree sitter. Splits the code in the
  block into imports/rest and then moves the imports to the top of the
  file and injects rest of the code into ob-deno-function-wrapper so
  that imports can be executed.
- Now org tables can be fed into ob-deno blocks as objects, instead of
  arrays. i.e. the following table
    ```
    | Date         | Speed     | Accuracy |
    |--------------+-----------+----------|
    | [2024-10-26] | 73.6 WPM  |      91% |
    | [2024-10-27] | 73.75 WPM |    88.5% |
    | [2024-10-28] | 76.2 WPM  |    92.5% |
    | [2024-11-01] | 75.66 WPM |   90.05% |
    ```  
  will be converted into the following:
    ```
    let data = [
      { date: "[2024-10-26]", speed: "33.6 WPM", accuracy: "91%" },
      { date: "[2024-10-27]", speed: "33.75 WPM", accuracy: "88.5%" },
      { date: "[2024-10-28]", speed: "36.2 WPM", accuracy: "92.5%" },
      { date: "[2024-11-01]", speed: "35.66 WPM", accuracy: "90.05%" }
    ];
    ```
- Did a few syntactic changes.
- Cleared byte-compiler and checkdoc warnings.

This PR also contains the #1.
